### PR TITLE
Ensures deterministic signatures for same H/R/S.

### DIFF
--- a/signer/threshold_validator.go
+++ b/signer/threshold_validator.go
@@ -451,8 +451,8 @@ func (pv *ThresholdValidator) compareBlockSignatureAgainstSSC(
 		return nil, nil, stamp, err
 	}
 
-	// only differ by timestamp, okay to sign again
-	return nil, nil, stamp, nil
+	// Ensures deterministic signatures for same H/R/S.
+	return existingSignature.Signature, existingSignature.VoteExtensionSignature, stamp, nil
 }
 
 // compareBlockSignatureAgainstHRS returns a BeyondBlockError if the hrs is greater than the


### PR DESCRIPTION
This PR potentially fixes the double-singing problem for the same  H/R/S.
More context 

<img width="720" height="506" alt="image" src="https://github.com/user-attachments/assets/cf5b19d8-a223-4aa2-8cd7-803f9c326356" />


A similar check exists in [Come, the privval folder](https://github.com/cometbft/cometbft/blob/d22299509a50140b74d81b113c4d78e4cf501994/privval/file.go#L455) that prevent's using new time.