### PR TITLE
Fix proto.Equal comparison issue causing false "conflicting data" errors

### DIFF
--- a/signer/file.go
+++ b/signer/file.go
@@ -7,8 +7,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/cosmos/gogoproto/proto"
-
 	"github.com/cometbft/cometbft/crypto"
 	"github.com/cometbft/cometbft/crypto/ed25519"
 	cometjson "github.com/cometbft/cometbft/libs/json"
@@ -248,6 +246,8 @@ func (pv *FilePV) Sign(chainID string, block Block) ([]byte, []byte, time.Time, 
 			}
 		}
 
+		// If we get here, the votes/proposals differ in more than just timestamp
+		// This is the "conflicting data" case that prevents race conditions
 		return nil, extSig, block.Timestamp, fmt.Errorf("conflicting data")
 	}
 
@@ -308,38 +308,131 @@ func (pv *FilePV) saveSigned(height int64, round int32, step int8,
 // returns true if the only difference in the votes is their timestamp.
 func checkVotesOnlyDifferByTimestamp(lastSignBytes, newSignBytes []byte) (time.Time, bool) {
 	var lastVote, newVote cometproto.CanonicalVote
+	
+	// Unmarshal with error handling - return false instead of panic
 	if err := protoio.UnmarshalDelimited(lastSignBytes, &lastVote); err != nil {
-		panic(fmt.Sprintf("LastSignBytes cannot be unmarshalled into vote: %v", err))
+		// Log the error for debugging but don't panic
+		fmt.Printf("WARNING: Failed to unmarshal lastSignBytes as vote: %v\n", err)
+		return time.Time{}, false
 	}
 	if err := protoio.UnmarshalDelimited(newSignBytes, &newVote); err != nil {
-		panic(fmt.Sprintf("signBytes cannot be unmarshalled into vote: %v", err))
+		// Log the error for debugging but don't panic
+		fmt.Printf("WARNING: Failed to unmarshal newSignBytes as vote: %v\n", err)
+		return time.Time{}, false
 	}
-
+	
+	// Save the timestamp from the last vote before comparison
 	lastTime := lastVote.Timestamp
-	// set the times to the same value and check equality
-	now := time.Now()
-	lastVote.Timestamp = now
-	newVote.Timestamp = now
-
-	return lastTime, proto.Equal(&newVote, &lastVote)
+	
+	// Manual field-by-field comparison to avoid proto.Equal issues
+	// Check Type
+	if lastVote.Type != newVote.Type {
+		return lastTime, false
+	}
+	
+	// Check Height
+	if lastVote.Height != newVote.Height {
+		return lastTime, false
+	}
+	
+	// Check Round
+	if lastVote.Round != newVote.Round {
+		return lastTime, false
+	}
+	
+	// Check ChainID
+	if lastVote.ChainID != newVote.ChainID {
+		return lastTime, false
+	}
+	
+	// Compare BlockID - handle nil cases carefully
+	if (lastVote.BlockID == nil) != (newVote.BlockID == nil) {
+		// One is nil, the other is not
+		return lastTime, false
+	}
+	
+	if lastVote.BlockID != nil {
+		// Both are non-nil, compare the fields
+		if !bytes.Equal(lastVote.BlockID.Hash, newVote.BlockID.Hash) {
+			return lastTime, false
+		}
+		
+		// Compare PartSetHeader
+		if lastVote.BlockID.PartSetHeader.Total != newVote.BlockID.PartSetHeader.Total {
+			return lastTime, false
+		}
+		if !bytes.Equal(lastVote.BlockID.PartSetHeader.Hash, newVote.BlockID.PartSetHeader.Hash) {
+			return lastTime, false
+		}
+	}
+	
+	// All fields match except (potentially) timestamp
+	// This means the votes only differ by timestamp
+	return lastTime, true
 }
 
 // returns the timestamp from the lastSignBytes.
 // returns true if the only difference in the proposals is their timestamp
 func checkProposalsOnlyDifferByTimestamp(lastSignBytes, newSignBytes []byte) (time.Time, bool) {
 	var lastProposal, newProposal cometproto.CanonicalProposal
+	// Unmarshal with error handling - return false instead of panic
 	if err := protoio.UnmarshalDelimited(lastSignBytes, &lastProposal); err != nil {
-		panic(fmt.Sprintf("LastSignBytes cannot be unmarshalled into proposal: %v", err))
+		// Log the error for debugging but don't panic
+		fmt.Printf("WARNING: Failed to unmarshal lastSignBytes as proposal: %v\n", err)
+		return time.Time{}, false
 	}
 	if err := protoio.UnmarshalDelimited(newSignBytes, &newProposal); err != nil {
-		panic(fmt.Sprintf("signBytes cannot be unmarshalled into proposal: %v", err))
+		// Log the error for debugging but don't panic
+		fmt.Printf("WARNING: Failed to unmarshal newSignBytes as proposal: %v\n", err)
+		return time.Time{}, false
 	}
 
+	// Save the timestamp from the last proposal before comparison
 	lastTime := lastProposal.Timestamp
-	// set the times to the same value and check equality
-	now := time.Now()
-	lastProposal.Timestamp = now
-	newProposal.Timestamp = now
 
-	return lastTime, proto.Equal(&newProposal, &lastProposal)
+	// Manual field-by-field comparison to avoid proto.Equal issues
+	// Check Type
+	if lastProposal.Type != newProposal.Type {
+		return lastTime, false
+	}
+	// Check Height
+	if lastProposal.Height != newProposal.Height {
+		return lastTime, false
+	}
+	// Check Round
+	if lastProposal.Round != newProposal.Round {
+		return lastTime, false
+	}
+	// Check POLRound
+	if lastProposal.POLRound != newProposal.POLRound {
+		return lastTime, false
+	}
+	// Check ChainID
+	if lastProposal.ChainID != newProposal.ChainID {
+		return lastTime, false
+	}
+
+	// Compare BlockID - handle nil cases carefully
+	if (lastProposal.BlockID == nil) != (newProposal.BlockID == nil) {
+		// One is nil, the other is not
+		return lastTime, false
+	}
+	
+	if lastProposal.BlockID != nil {
+		// Both are non-nil, compare the fields
+		if !bytes.Equal(lastProposal.BlockID.Hash, newProposal.BlockID.Hash) {
+			return lastTime, false
+		}
+		// Compare PartSetHeader
+		if lastProposal.BlockID.PartSetHeader.Total != newProposal.BlockID.PartSetHeader.Total {
+			return lastTime, false
+		}
+		if !bytes.Equal(lastProposal.BlockID.PartSetHeader.Hash, newProposal.BlockID.PartSetHeader.Hash) {
+			return lastTime, false
+		}
+	}
+	
+	// All fields match except (potentially) timestamp
+	// This means the proposals only differ by timestamp
+	return lastTime, true
 }


### PR DESCRIPTION
  ### Description

  This PR fixes a critical issue where `proto.Equal()` fails with "proto: don't know how to compare 0" error when comparing votes/proposals that only differ by timestamp. This bug prevents the timestamp reuse logic from working correctly, resulting in unnecessary "conflicting data" errors.

  ### Problem

  When multiple sentries request signatures for the same block with different timestamps, Horcrux should reuse the previous signature if the votes only differ by timestamp. However, `proto.Equal()` was failing to properly compare the protobuf messages, causing false negative comparisons and triggering "conflicting data" errors.

  The logs show:
```
All fields match (except timestamp)
  proto: don't know how to compare 0
  [DEBUG] proto.Equal result: false
  Failed to sign type=prevote chain_id=injective-test-1 height=324792 round=0 error="conflicting data"
```
<img width="2672" height="1527" alt="스크린샷 2025-08-05 오후 2 17 39" src="https://github.com/user-attachments/assets/fefa28c8-ea07-414a-8001-6a8525a75563" />



  ### Root Cause

  The `proto.Equal()` function from gogoproto library encounters unknown fields or extensions in the protobuf messages unmarshalled via `protoio.UnmarshalDelimited()`. When it can't handle these fields, it logs "proto: don't know how to compare X" and returns false, even when all visible fields are identical.

  ### Solution

  Replace `proto.Equal()` with manual field-by-field comparison in both:
  - `checkVotesOnlyDifferByTimestamp()`
  - `checkProposalsOnlyDifferByTimestamp()`

  The manual comparison checks all relevant fields (Type, Height, Round, BlockID, ChainID) while ignoring any internal protobuf metadata that was causing the comparison to fail.

  ### Changes

  1. **Manual field comparison**: Replaced `proto.Equal()` with explicit comparison of all fields
  2. **Improved error handling**: Return false instead of panic on unmarshal errors
  3. **Better nil handling**: Use XOR pattern `(a == nil) != (b == nil)` for clearer nil checks
  4. **Added logging**: Log warnings when unmarshal fails for debugging

  ### Testing

  The fix has been verified to resolve the "conflicting data" errors in private testnet logs. The timestamp reuse logic now works correctly when votes/proposals only differ by timestamp.

  ### Impact

  This fix is critical for validators using multiple sentries, as it prevents unnecessary signing failures and reduces the risk of double signing by properly reusing signatures when appropriate. 